### PR TITLE
Burnside's lemma

### DIFF
--- a/C++/Burnside's lemma
+++ b/C++/Burnside's lemma
@@ -1,0 +1,50 @@
+using Permutation = vector<int>;
+
+void operator*=(Permutation& p, Permutation const& q) {
+    Permutation copy = p;
+    for (int i = 0; i < p.size(); i++)
+        p[i] = copy[q[i]];
+}
+
+int count_cycles(Permutation p) {
+    int cnt = 0;
+    for (int i = 0; i < p.size(); i++) {
+        if (p[i] != -1) {
+            cnt++;
+            for (int j = i; p[j] != -1;) {
+                int next = p[j];
+                p[j] = -1;
+                j = next;
+            }
+        }
+    }
+    return cnt;
+}
+
+int solve(int n, int m) {
+    Permutation p(n*m), p1(n*m), p2(n*m), p3(n*m);
+    for (int i = 0; i < n*m; i++) {
+        p[i] = i;
+        p1[i] = (i % n + 1) % n + i / n * n;
+        p2[i] = (i / n + 1) % m * n + i % n;
+        p3[i] = (m - 1 - i / n) * n + (n - 1 - i % n);
+    }
+
+    set<Permutation> s;
+    for (int i1 = 0; i1 < n; i1++) {
+        for (int i2 = 0; i2 < m; i2++) {
+            for (int i3 = 0; i3 < 2; i3++) {
+                s.insert(p);
+                p *= p3;
+            }
+            p *= p2;
+        }
+        p *= p1;
+    }
+
+    int sum = 0;
+    for (Permutation const& p : s) {
+        sum += 1 << count_cycles(p);
+    }
+    return sum / s.size();
+}


### PR DESCRIPTION
Burnside's lemma allows us to count the number of equivalence classes in sets, based on internal symmetry.